### PR TITLE
Redirect to novel after login

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,0 +1,126 @@
+<?php
+session_start();
+
+const VALID_USERNAME = 'Smørbukk';
+const VALID_PASSWORD = 'Huldra';
+
+if (isset($_GET['logout'])) {
+    $_SESSION = [];
+    if (ini_get('session.use_cookies')) {
+        $params = session_get_cookie_params();
+        setcookie(
+            session_name(),
+            '',
+            time() - 42000,
+            $params['path'],
+            $params['domain'],
+            $params['secure'],
+            $params['httponly']
+        );
+    }
+    session_destroy();
+    header('Location: index.php');
+    exit;
+}
+
+$error = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = $_POST['username'] ?? '';
+    $password = $_POST['password'] ?? '';
+
+    if (hash_equals(VALID_USERNAME, $username) && hash_equals(VALID_PASSWORD, $password)) {
+        $_SESSION['logged_in'] = true;
+        $_SESSION['username'] = VALID_USERNAME;
+        header('Location: novel.html');
+        exit;
+    }
+
+    $error = 'Ugyldig brukernavn eller passord.';
+    $_SESSION['logged_in'] = false;
+    unset($_SESSION['username']);
+}
+
+$loggedIn = $_SESSION['logged_in'] ?? false;
+
+if ($loggedIn) {
+    header('Location: novel.html');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="no">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Innlogging</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            display: flex;
+            min-height: 100vh;
+            align-items: center;
+            justify-content: center;
+            background-color: #f5f5f5;
+        }
+        .login-container {
+            background: #ffffff;
+            border-radius: 8px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+            padding: 2rem;
+            width: 100%;
+            max-width: 360px;
+        }
+        h1 {
+            margin-top: 0;
+            text-align: center;
+        }
+        label {
+            display: block;
+            margin-bottom: 0.5rem;
+            font-weight: bold;
+        }
+        input[type="text"],
+        input[type="password"] {
+            width: 100%;
+            padding: 0.5rem;
+            margin-bottom: 1rem;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+        }
+        button {
+            width: 100%;
+            padding: 0.6rem;
+            background-color: #007bff;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 1rem;
+        }
+        button:hover {
+            background-color: #0056b3;
+        }
+        .error {
+            color: #d93025;
+            margin-bottom: 1rem;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+<div class="login-container">
+    <h1>Logg inn</h1>
+    <?php if ($error): ?>
+        <div class="error"><?php echo htmlspecialchars($error, ENT_QUOTES, 'UTF-8'); ?></div>
+    <?php endif; ?>
+    <form method="post" action="">
+        <label for="username">Brukernavn</label>
+        <input type="text" id="username" name="username" required>
+        <label for="password">Passord</label>
+        <input type="password" id="password" name="password" required>
+        <button type="submit">Logg inn</button>
+    </form>
+</div>
+</body>
+</html>

--- a/novel.html
+++ b/novel.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="no">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Eventyret om Smørbukk</title>
+    <style>
+        body {
+            font-family: "Georgia", serif;
+            background: #faf6f0;
+            color: #2f1b0c;
+            margin: 0;
+            padding: 2rem;
+            line-height: 1.6;
+        }
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            background: #ffffff;
+            padding: 2.5rem;
+            border-radius: 10px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+        }
+        h1 {
+            text-align: center;
+            margin-top: 0;
+        }
+        .logout {
+            margin-top: 2rem;
+            text-align: center;
+        }
+        .logout a {
+            color: #007bff;
+            text-decoration: none;
+            font-weight: bold;
+        }
+        .logout a:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Eventyret om Smørbukk</h1>
+    <p>
+        Når Smørbukk tok steget over terskelen til den skjulte skogen, luktet luften av granbar
+        og regnvått løv. Han hadde ventet lenge på dette øyeblikket &ndash; et møte med Huldra, som
+        hvisket ham drømmer i søvnen og ba ham våge å følge etter.
+    </p>
+    <p>
+        Mellom stammene skimtet han et svakt blått lys som pulserte i takt med hjertet hans.
+        Hvert skritt førte ham dypere inn, og snart stod han foran den gamle eika som voktet
+        inngangen til hulen. Et slør av tåke lå over mosen, og midt i alt sto Huldra. Hennes
+        øyne, dypere enn fjorden en høstdag, møtte hans uten et ord.
+    </p>
+    <p>
+        «Du kom,» sa hun, og stemmen bar både vindens sus og fossens kraft. «Veien hit er lang,
+        men den er din. Så lenge du husker hvem du er, vil skogen alltid vise deg veien hjem.»
+        Med det tok hun hånden hans, og sammen forsvant de innover blant lyse trær og dunkle
+        skygger, der eventyrene skrev seg selv hver eneste dag.
+    </p>
+    <div class="logout">
+        <a href="index.php?logout=1">Logg ut</a>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- redirect successful logins straight to the new novel.html page
- simplify the index.php view to only show the login form and error feedback
- add a styled novel.html story page with a logout link back to the login screen

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68d445ea5e748323b11056e2b2428cb3